### PR TITLE
Implemented serial number

### DIFF
--- a/Core V2.3.2/BackEnd/BackEnd.ino
+++ b/Core V2.3.2/BackEnd/BackEnd.ino
@@ -120,6 +120,8 @@ bool UseEthernet = 0;                    //1 if we should be using ethernet
 bool UseWiFi = 0;                        //1 if we should be using wifi
 char InterfaceUsed;                      //0 if using WiFi, 1 if using Ethernet.
 String PreState;                         //What state the system was in right before a keycard is inserted, to prevent glitches to the state.
+String SerialNumber;                     //Plaintext store of the shlug identifier from OneWire
+bool JustDisconnected;                   //Lets us detect if a websocket was just dropped or has been for a bit.
 
 //Libraries:
 #include <OneWireESP32.h>         //Version 2.0.2 | Source: https://github.com/junkfix/esp32-ds18b20
@@ -224,6 +226,7 @@ void setup(){
     //Nuke the rest of this process - we can't do anything without our config.
     vTaskSuspend(NULL);
   }
+  SerialNumber = settings.getString("SerialNumber");
   Password = settings.getString("Password");
   if(Password.equalsIgnoreCase("null")){
     //Use a real NULL password.

--- a/Core V2.3.2/BackEnd/SocketManager.ino
+++ b/Core V2.3.2/BackEnd/SocketManager.ino
@@ -188,6 +188,7 @@ void SocketManager(void *pvParameters) {
       wsresp["FWVersion"] = Version;
       wsresp["HWVersion"] = Hardware;
       wsresp["HWType"] = "ACS Core";
+      wsresp["SerialNumber"] = SerialNumber;
       //Determine if this is the first time we are sending this since startup. 
       if(MessageNumber > 0){
         //We've sent messages in the past, reset the message count but no need to ask for anything special
@@ -303,11 +304,17 @@ void authUser(JsonDocument input){
 void webSocketEvent(WStype_t type, uint8_t * payload, size_t length) {
   switch(type) {
     case WStype_DISCONNECTED:
-      Serial.printf("[WSc] Disconnected!\n");
+      if(JustDisconnected){
+        //Stops spam if we have no connection
+        Serial.printf("[WSc] Disconnected!\n");
+        JustDisconnected = 0;
+      }
+
       NoNetwork = 1;
       WSSend = 0; //Clear out anything that needs to be sent
       break;
     case WStype_CONNECTED:
+      JustDisconnected = 1;
       Serial.println(F("Connected."));
       Serial.printf("[WSc] Connected to url: %s\n", payload);
       SendWSReconnect = 1;

--- a/Core V2.3.2/BackEnd/Temperature.ino
+++ b/Core V2.3.2/BackEnd/Temperature.ino
@@ -19,7 +19,7 @@ void Temperature(void *pvParameters){
 	//First time running, find the addresses
   if(DebugMode){
     xSemaphoreTake(DebugMutex, portMAX_DELAY);
-    Serial.println(F("First time running temperature..."));
+    Serial.println(F("First time running OneWire..."));
     xSemaphoreGive(DebugMutex);
   }
   xSemaphoreTake(OneWireMutex, portMAX_DELAY); 
@@ -36,6 +36,19 @@ void Temperature(void *pvParameters){
     //Something has gone wrong, there should be at least 1 temperature sensor. Restart?
     Serial.println(F("ERROR: Found no OneWire devices?"));
     ESP.restart();
+  }
+  if(devices == 1){
+    //We found the internal onewire, this is what the Shlug should use to identify itself.
+    if(SerialNumber == NULL){
+      //The serial number has not been saved yet, save what we found
+      SerialNumber = String(SerialNumbers[0], HEX);
+      SerialNumber.toUpperCase();
+      if(DebugMode){
+        Serial.print(F("Saving Serial Number: "));
+        Serial.println(SerialNumber);
+      }
+      settings.putString("SerialNumber", SerialNumber);
+    }
   }
   xSemaphoreGive(OneWireMutex);
 


### PR DESCRIPTION
ESP now gets the ID of the onewire device if there is only one device, this would be the one on the PCB itself. Saves this as the serial number in preferences.