### PR TITLE
Report HardwareIDs

### DIFF
--- a/Core V2.3.2/BackEnd/BackEnd.ino
+++ b/Core V2.3.2/BackEnd/BackEnd.ino
@@ -29,7 +29,7 @@ USBConfig: Allows programatic changing of settings over USB
 //Settings
 #define Version "1.3.1"
 #define Hardware "2.3.2-LE"
-#define MAX_DEVICES 2 //How many possible temperature sensors to scan for
+#define MAX_DEVICES 5 //How many possible temperature sensors to scan for
 #define OTA_URL "https://raw.githubusercontent.com/rit-construct-makerspace/access-control-firmware/refs/heads/main/otadirectory.json"
 #define TemperatureTime 5000 //How long to delay between temperature measurements, in milliseconds
 #define FEPollRate 10000 //How long, in milliseconds, to go between an all-values poll of the frontend (in addition to event-based)
@@ -47,6 +47,7 @@ USBConfig: Allows programatic changing of settings over USB
 //Global Variables:
 bool TemperatureUpdate;                  //1 when writing new information, to indicate other devices shouldn't read temperature-related info
 uint64_t SerialNumbers[MAX_DEVICES];     //an array of uint64_t serial numbers of the devices. Size of the array is based on MAX_DEVICES 
+char devices;                            //How many onewire devices were detected, and therefore how many hardware components make up the ACS deployment
 float SysMaxTemp;                        //a float of the maximum temperature of the system
 bool DebugPrinting;                      //1 when a thread is writing on debug serial
 bool DebugMode = 1;                      //1 when debug data should be printed, always starts at 1. WARNING: Will plain-text print sensitive information!

--- a/Core V2.3.2/BackEnd/SocketManager.ino
+++ b/Core V2.3.2/BackEnd/SocketManager.ino
@@ -189,6 +189,15 @@ void SocketManager(void *pvParameters) {
       wsresp["HWVersion"] = Hardware;
       wsresp["HWType"] = "ACS Core";
       wsresp["SerialNumber"] = SerialNumber;
+      if(devices == 0){
+        //The Onewire manager hasn't finished finding IDs yet
+        delay(50);
+      }
+      for (uint8_t i = 0; i < devices; i += 1) {
+        String TempID = String(SerialNumbers[i],HEX);
+        TempID.toUpperCase();
+        wsresp["HardwareIDs"][i] = TempID;
+      }
       //Determine if this is the first time we are sending this since startup. 
       if(MessageNumber > 0){
         //We've sent messages in the past, reset the message count but no need to ask for anything special

--- a/Core V2.3.2/BackEnd/Temperature.ino
+++ b/Core V2.3.2/BackEnd/Temperature.ino
@@ -23,7 +23,7 @@ void Temperature(void *pvParameters){
     xSemaphoreGive(DebugMutex);
   }
   xSemaphoreTake(OneWireMutex, portMAX_DELAY); 
-	uint8_t devices = ds.search(SerialNumbers, MAX_DEVICES);
+	devices = ds.search(SerialNumbers, MAX_DEVICES);
 	for (uint8_t i = 0; i < devices; i += 1) {
     if(DebugMode){
       if(xSemaphoreTake(DebugMutex,(5/portTICK_PERIOD_MS)) == pdTRUE){


### PR DESCRIPTION
On initial websocket message, the system now reports an array of strings called HardwareIDs, that is the ID of each device in the ACS deployment. Used by server for integrity checks in the future.